### PR TITLE
Update item density on belts for 0.17

### DIFF
--- a/OB_helper.lua
+++ b/OB_helper.lua
@@ -199,7 +199,7 @@ function OB_helper.choose_belt(state, row_details)
         if state.miner_res_per_sec then
             local res_per_sec =
                 math.max(row_details.miner_count_below, row_details.miner_count_above) * 2 * state.miner_res_per_sec
-            required_belt_speed = (res_per_sec / 7.111) / 60
+            required_belt_speed = (res_per_sec / 8) / 60
         end
 
         -- Resources required from this row to have fully compressed output


### PR DESCRIPTION
Starting with 0.17.0, item density on belts changed from 7.111 to 8.  See https://stable.wiki.factorio.com/Transport_belt for 0.16, versus https://wiki.factorio.com/Transport_belt for 0.17, or search for "Item spacing" on https://wiki.factorio.com/Version_history/0.17.0 .